### PR TITLE
allow the aws credentials profile to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ staging_root = "/path/to/staging/root"
 # The next properties only apply when using S3
 # The AWS region your bucket is in
 region = "aws-region"
+# The AWS credentials profile to load credentials from. If not specified, "default" is used.
+profile = "aws-credentials-profile"
 # The URL to the S3 endpoint. This is only needed if you are using a non-standard region
 endpoint = "https://s3-endpoint"
 # The S3 bucket the OCFL repository is in
@@ -530,6 +532,7 @@ To connect to an OCFL repository in S3, you first need to create an
 IAM user with access to the S3 bucket, and then setup a local
 `~/.aws/credentials` file or environment variables as [described
 here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
+Credential profiles can be specified using the `--profile` option.
 Then, when you invoke `rocfl` you must specify the bucket the
 repository is in as well as the bucket region. For example:
 

--- a/resources/main/files/config.toml
+++ b/resources/main/files/config.toml
@@ -17,9 +17,10 @@
 # [my-fs-repo]
 # root = "/path/to/storage/root"
 #
-# # This is repository specific configuratio for a remote S3 repository.
+# # This is repository specific configuration for a remote S3 repository.
 # # You can acitivate this config by invoking rocfl with '-n my-s3-repo'
 # [my-s3-repo]
+# profile = "my-aws-credentials-profile"
 # region = "us-east-2"
 # bucket = "my-example-ocfl-bucket"
 # root = "my-s3-repo"

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -220,6 +220,7 @@ fn create_s3_repo(config: &Config) -> Result<OcflRepo> {
     OcflRepo::s3_repo(
         region,
         config.bucket.as_ref().unwrap(),
+        config.profile.as_deref(),
         config.root.as_deref(),
         config.staging_root.as_ref().unwrap(),
     )
@@ -232,6 +233,7 @@ fn init_s3_repo(config: &Config, layout: Option<StorageLayout>) -> Result<OcflRe
     OcflRepo::init_s3_repo(
         region,
         config.bucket.as_ref().unwrap(),
+        config.profile.as_deref(),
         config.root.as_deref(),
         config.staging_root.as_ref().unwrap(),
         layout,
@@ -264,6 +266,9 @@ fn resolve_config(args: &RocflArgs, mut config: Config) -> Config {
     }
     if args.endpoint.is_some() {
         config.endpoint = args.endpoint.clone();
+    }
+    if args.profile.is_some() {
+        config.profile = args.profile.clone()
     }
 
     if let Command::Commit(commit) = &args.command {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -220,9 +220,9 @@ fn create_s3_repo(config: &Config) -> Result<OcflRepo> {
     OcflRepo::s3_repo(
         region,
         config.bucket.as_ref().unwrap(),
-        config.profile.as_deref(),
         config.root.as_deref(),
         config.staging_root.as_ref().unwrap(),
+        config.profile.as_deref(),
     )
 }
 
@@ -233,10 +233,10 @@ fn init_s3_repo(config: &Config, layout: Option<StorageLayout>) -> Result<OcflRe
     OcflRepo::init_s3_repo(
         region,
         config.bucket.as_ref().unwrap(),
-        config.profile.as_deref(),
         config.root.as_deref(),
         config.staging_root.as_ref().unwrap(),
         layout,
+        config.profile.as_deref(),
     )
 }
 

--- a/src/cmd/opts.rs
+++ b/src/cmd/opts.rs
@@ -68,6 +68,10 @@ pub struct RocflArgs {
     #[structopt(short, long, value_name = "ENDPOINT")]
     pub endpoint: Option<String>,
 
+    /// AWS profile to load credentials from.
+    #[structopt(short, long, value_name = "PROFILE")]
+    pub profile: Option<String>,
+
     /// Suppress error messages
     #[structopt(short, long)]
     pub quiet: bool,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -22,6 +22,7 @@ pub struct Config {
     pub region: Option<String>,
     pub bucket: Option<String>,
     pub endpoint: Option<String>,
+    pub profile: Option<String>,
 }
 
 impl Config {
@@ -34,6 +35,7 @@ impl Config {
             region: None,
             bucket: None,
             endpoint: None,
+            profile: None,
         }
     }
 
@@ -136,6 +138,7 @@ fn resolve_config(name: &Option<String>, mut config: HashMap<String, Config>) ->
             resolved.region = resolve_field(global.region, repo.region);
             resolved.bucket = resolve_field(global.bucket, repo.bucket);
             resolved.endpoint = resolve_field(global.endpoint, repo.endpoint);
+            resolved.profile = resolve_field(global.profile, repo.profile);
 
             resolved
         }

--- a/src/ocfl/repo.rs
+++ b/src/ocfl/repo.rs
@@ -94,14 +94,14 @@ impl OcflRepo {
     pub fn init_s3_repo(
         region: Region,
         bucket: &str,
-        profile: Option<&str>,
         prefix: Option<&str>,
         staging_root: impl AsRef<Path>,
         layout: Option<StorageLayout>,
+        profile: Option<&str>,
     ) -> Result<Self> {
         Ok(Self {
             staging_root: staging_root.as_ref().to_path_buf(),
-            store: Box::new(S3OcflStore::init(region, bucket, profile, prefix, layout)?),
+            store: Box::new(S3OcflStore::init(region, bucket, prefix, layout, profile)?),
             staging: OnceCell::default(),
             staging_lock_manager: OnceCell::default(),
             use_backslashes: false,
@@ -115,13 +115,13 @@ impl OcflRepo {
     pub fn s3_repo(
         region: Region,
         bucket: &str,
-        profile: Option<&str>,
         prefix: Option<&str>,
         staging_root: impl AsRef<Path>,
+        profile: Option<&str>,
     ) -> Result<Self> {
         Ok(Self {
             staging_root: staging_root.as_ref().to_path_buf(),
-            store: Box::new(S3OcflStore::new(region, bucket, profile, prefix)?),
+            store: Box::new(S3OcflStore::new(region, bucket, prefix, profile)?),
             staging: OnceCell::default(),
             staging_lock_manager: OnceCell::default(),
             use_backslashes: false,

--- a/src/ocfl/repo.rs
+++ b/src/ocfl/repo.rs
@@ -94,13 +94,14 @@ impl OcflRepo {
     pub fn init_s3_repo(
         region: Region,
         bucket: &str,
+        profile: Option<&str>,
         prefix: Option<&str>,
         staging_root: impl AsRef<Path>,
         layout: Option<StorageLayout>,
     ) -> Result<Self> {
         Ok(Self {
             staging_root: staging_root.as_ref().to_path_buf(),
-            store: Box::new(S3OcflStore::init(region, bucket, prefix, layout)?),
+            store: Box::new(S3OcflStore::init(region, bucket, profile, prefix, layout)?),
             staging: OnceCell::default(),
             staging_lock_manager: OnceCell::default(),
             use_backslashes: false,
@@ -114,12 +115,13 @@ impl OcflRepo {
     pub fn s3_repo(
         region: Region,
         bucket: &str,
+        profile: Option<&str>,
         prefix: Option<&str>,
         staging_root: impl AsRef<Path>,
     ) -> Result<Self> {
         Ok(Self {
             staging_root: staging_root.as_ref().to_path_buf(),
-            store: Box::new(S3OcflStore::new(region, bucket, prefix)?),
+            store: Box::new(S3OcflStore::new(region, bucket, profile, prefix)?),
             staging: OnceCell::default(),
             staging_lock_manager: OnceCell::default(),
             use_backslashes: false,

--- a/src/ocfl/store/s3.rs
+++ b/src/ocfl/store/s3.rs
@@ -58,10 +58,10 @@ impl S3OcflStore {
     pub fn new(
         region: Region,
         bucket: &str,
-        profile: Option<&str>,
         prefix: Option<&str>,
+        profile: Option<&str>,
     ) -> Result<Self> {
-        let s3_client = S3Client::new(region, bucket, profile, prefix)?;
+        let s3_client = S3Client::new(region, bucket, prefix, profile)?;
 
         check_extensions(&s3_client);
         let storage_layout = load_storage_layout(&s3_client);
@@ -79,11 +79,11 @@ impl S3OcflStore {
     pub fn init(
         region: Region,
         bucket: &str,
-        profile: Option<&str>,
         prefix: Option<&str>,
         layout: Option<StorageLayout>,
+        profile: Option<&str>,
     ) -> Result<Self> {
-        let s3_client = S3Client::new(region, bucket, profile, prefix)?;
+        let s3_client = S3Client::new(region, bucket, prefix, profile)?;
 
         init_new_repo(&s3_client, layout.as_ref())?;
 
@@ -550,8 +550,8 @@ impl S3Client {
     fn new(
         region: Region,
         bucket: &str,
-        profile: Option<&str>,
         prefix: Option<&str>,
+        profile: Option<&str>,
     ) -> Result<Self> {
         Ok(S3Client {
             s3_client: create_rusoto_client(region, profile),

--- a/src/ocfl/store/s3.rs
+++ b/src/ocfl/store/s3.rs
@@ -595,18 +595,23 @@ impl S3Client {
                         ..Default::default()
                     }))?;
 
+            let prefix_offset = if self.prefix.is_empty() {
+                0
+            } else {
+                self.prefix.len() + 1
+            };
+
             if let Some(contents) = &result.contents {
                 for object in contents {
-                    objects.push(object.key.as_ref().unwrap()[self.prefix.len() + 1..].to_owned());
+                    objects.push(object.key.as_ref().unwrap()[prefix_offset..].to_owned());
                 }
             }
 
             if let Some(prefixes) = &result.common_prefixes {
                 for prefix in prefixes {
                     let length = prefix.prefix.as_ref().unwrap().len() - 1;
-                    directories.push(
-                        prefix.prefix.as_ref().unwrap()[self.prefix.len() + 1..length].to_owned(),
-                    );
+                    directories
+                        .push(prefix.prefix.as_ref().unwrap()[prefix_offset..length].to_owned());
                 }
             }
 

--- a/tests/s3-tests.rs
+++ b/tests/s3-tests.rs
@@ -602,7 +602,7 @@ fn default_repo(prefix: &str, staging: impl AsRef<Path>) -> OcflRepo {
 }
 
 fn init_repo(prefix: &str, staging: impl AsRef<Path>, layout: Option<StorageLayout>) -> OcflRepo {
-    OcflRepo::init_s3_repo(REGION, &bucket(), None, Some(prefix), staging, layout).unwrap()
+    OcflRepo::init_s3_repo(REGION, &bucket(), Some(prefix), staging, layout, None).unwrap()
 }
 
 fn s3_prefix() -> String {

--- a/tests/s3-tests.rs
+++ b/tests/s3-tests.rs
@@ -602,7 +602,7 @@ fn default_repo(prefix: &str, staging: impl AsRef<Path>) -> OcflRepo {
 }
 
 fn init_repo(prefix: &str, staging: impl AsRef<Path>, layout: Option<StorageLayout>) -> OcflRepo {
-    OcflRepo::init_s3_repo(REGION, &bucket(), Some(prefix), staging, layout).unwrap()
+    OcflRepo::init_s3_repo(REGION, &bucket(), None, Some(prefix), staging, layout).unwrap()
 }
 
 fn s3_prefix() -> String {


### PR DESCRIPTION
Adds a new `--profile` option at the root level that allows an [aws credentials profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) to be specified. This option can also be specified in the config file.

Example usage:

```shell
rocfl -p my-profile -b my-bucket -R us-east-2 ls
```

Resolves https://github.com/pwinckles/rocfl/issues/5